### PR TITLE
Add DCAT-AP case studies

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,7 +76,9 @@ nav:
           - Mapping LGBTQ+-related thesauri: case-study/case-study-lgbtq.md
           - Fresh Catalog: case-study/case-study-fresh.md
           - BFO-PROV-O: case-study/case-study-bfoprov.md
-  - FAIR Mapping recommendations: recommendation.md          
+          - DCAT-AP-DataCite: case-study/case-study-dcat-ap-datacite.md
+          - DCAT-AP-Schema.org: case-study/case-study-dcat-ap-schemaorg.md
+  - FAIR Mapping recommendations: recommendation.md
   - Decision log of the Working Group: decision-log.md
   - Resources about FAIR mappings: resources.md
 repo_url: https://github.com/mapping-commons/rda-fair-mappings/

--- a/src/docs/case-study/case-study-dcat-ap-datacite.md
+++ b/src/docs/case-study/case-study-dcat-ap-datacite.md
@@ -1,0 +1,80 @@
+---
+title: "DCAT-AP to DataCite Case Study"
+author: "Philip Strömert"
+author_github: "@StroemPhi"
+date: "2025-07-17"
+tags:
+  - Semantic interoperability
+  - Integration
+  - Analysis
+  - Discovery
+  - Transformation
+category: "Case Studies"
+mapping_type: "Schema Mapping"
+status: "Draft"
+---
+
+Mapping DCAT-AP to the DataCite schema.
+
+### Summary
+
+Having a mapping between DCAT-AP and the DataCite metadata schema is needed to extract DCAT-AP conform metadata from DOI metadata or transform DCAT-AP based metadata into DataCite schema compliant metadata in otder to register a DOI for a dcat:Resource. But also having a mapping which allows such crosswalks might allow better discoverability, when combining the [PID graph](https://datacite.org/blog/introducing-the-pid-graph/) with other knowledge graphs.
+
+It would be great for NFDI and probably other innitiatives to evaluated if this draft is still up to date and to also provide other mapping representations than XSLT.
+
+### Domain
+
+domain-agnostic
+
+### Use case category
+
+- Semantic interoperability (shared understanding of data across multiple systems)
+- Integration (Connecting data across disparate resources)
+- Transformation (translating source data into a target schema)
+- Analysis (Aggregating data and driving new insights)
+
+### Purpose of the mapping
+
+From [documentation](https://ec-jrc.github.io/datacite-to-dcat-ap/#background):
+
+> The motivation for investigating the possiblity of aligning DataCite metadata with DCAT-AP is twofold:
+>
+> - To identify how to create a DCAT-AP-compliant representation of DataCite metadata, in order to enable their sharing across DCAT-AP-enabled data catalogues. This analysis is not meant to provide a complete representation of all DataCite metadata elements, but only of those included in DCAT-AP.
+> - To identify how to create a DataCite-compliant representation of DCAT-AP metadata, in order to enable their publishing on the DataCite infrastructure. This analysis is meant to develop an extension of DCAT-AP, covering all DataCite metadata elements.
+
+### Type of mapped resources
+
+It is about mapping metadata of datasets and other DCAT ressources to DataCite publications of the ResourceType "Dataset".
+
+### Links to an existing mappings
+
+The mapping is [delivered as an XSLT script](https://github.com/ec-jrc/datacite-to-dcat-ap/blob/master/datacite-to-dcat-ap.xsl).
+
+### Tools used for creating the mapping
+
+- [XSLT (Extensible Stylesheet Language Transformations)](https://ec-jrc.github.io/datacite-to-dcat-ap/#formal-definition-xslt)
+
+### Type of mapping relations
+
+- entity mapping (one-to-one & many-to-one)
+- structure / value mappings
+
+### Examples (samples) of different types of mapping implementations
+
+Example for mapping a title:
+
+```xsl
+<xsl:template name="Titles" match="*[local-name() = 'titles']/*[local-name() = 'title']">
+  <xsl:variable name="title" select="normalize-space(.)"/>
+  <xsl:choose>
+    <xsl:when test="normalize-space(@xml:lang) != ''">
+      <dct:title xml:lang="{@xml:lang}"><xsl:value-of select="$title"/></dct:title>
+    </xsl:when>
+    <xsl:otherwise>
+      <dct:title><xsl:value-of select="$title"/></dct:title>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+```
+
+See [source](https://github.com/ec-jrc/datacite-to-dcat-ap/blob/master/datacite-to-dcat-ap.xsl) for the full mapping.

--- a/src/docs/case-study/case-study-dcat-ap-datacite.md
+++ b/src/docs/case-study/case-study-dcat-ap-datacite.md
@@ -57,7 +57,7 @@ The mapping is [delivered as an XSLT script](https://github.com/ec-jrc/datacite-
 ### Type of mapping relations
 
 - entity mapping (one-to-one & many-to-one)
-- structure / value mappings
+- structure / schema / value mappings
 
 ### Examples (samples) of different types of mapping implementations
 

--- a/src/docs/case-study/case-study-dcat-ap-schemaorg.md
+++ b/src/docs/case-study/case-study-dcat-ap-schemaorg.md
@@ -1,0 +1,89 @@
+---
+title: "DCAT-AP to Schema.org Case Study"
+author: "Philip Strömert"
+author_github: "@StroemPhi"
+date: "2025-07-17"
+tags:
+  - Semantic interoperability
+  - Integration
+  - Discovery
+  - Transformation
+category: "Case Studies"
+mapping_type: "Schema Mapping"
+status: "Draft"
+---
+
+Mapping DCAT-AP to Schema.org.
+
+### Summary
+
+A [draft](https://ec-jrc.github.io/dcat-ap-to-schema-org/) meant to report work in progress concerning an exercise, carried out at the [Joint Research Centre of the European Commission](https://ec.europa.eu/jrc/) (Unit B.6), for mapping the relevant terms from the DCAT Application Profile for European Data Portals (DCAT-AP) to the Schema.org vocabulary.
+
+### Domain
+
+domain-agnostic
+
+### Use case category
+
+- Semantic interoperability (shared understanding of data across multiple systems)
+- Integration (Connecting data across disparate resources)
+- Transformation (translating source data into a target schema)
+- Discovery (finding related data across resources)
+
+### Purpose of the mapping
+
+- To identify how to create a DCAT-AP-compliant representation of Schema.org metadata, in order to enable their sharing across DCAT-AP-enabled data catalogues.
+- To identify how to create a Schema.org-compliant representation of DCAT-AP metadata, in order to enhance their discoverability on the Web.
+
+### Type of mapped resources
+
+Metadata about datasets.
+
+### Links to an existing mappings
+
+The mappings are [expressed as SPARQL construct queries](https://github.com/ec-jrc/dcat-ap-to-schema-org/tree/master/sparql) against the DCAT-AP model (constructing schema.org corresponding metadata).
+
+### Tools used for creating the mapping
+
+- [SPARQL construct queries](https://ec-jrc.github.io/dcat-ap-to-schema-org/#formal-definition-sparql)
+
+### Type of mapping relations
+
+- entity mappings - one to many & many-to-one
+- schema mappings - instances of DCAT-AP to schema.org.
+
+See also [notes about alignment issues](https://ec-jrc.github.io/dcat-ap-to-schema-org/#alignment-issues).
+
+### Examples (samples) of different types of mapping implementations
+
+```sparql
+PREFIX dct:    <http://purl.org/dc/terms/>
+PREFIX foaf:   <http://xmlns.com/foaf/0.1/>
+PREFIX locn:   <http://www.w3.org/ns/locn#>
+PREFIX org:    <http://www.w3.org/ns/org#>
+PREFIX schema: <http://schema.org/>
+
+CONSTRUCT {
+  ?Agent 
+    a ?schemaPerson ;
+    a ?schemaOrganization ;
+    schema:name ?name ;
+#    schema:?? ?AgentType ;
+    schema:address ?AgentAddress ;
+    schema:memberOf ?Affiliation ;
+    schema:email ?email ;
+    schema:url ?workplaceHomepage ;
+    schema:telephone ?phone
+} WHERE {
+  OPTIONAL { ?Agent a foaf:Agent . }
+  OPTIONAL { ?Agent a foaf:Person BIND(schema:Person AS ?schemaPerson) . }
+  OPTIONAL { ?Agent a foaf:Organization BIND(schema:Organization AS ?schemaOrganization) . }
+  OPTIONAL { ?Agent foaf:name ?name . }
+#  OPTIONAL { ?Agent dct:type ?AgentType . }
+  OPTIONAL { ?Agent locn:address ?AgentAddress . }
+  OPTIONAL { ?Agent org:memberOf ?Affiliation . }
+  OPTIONAL { ?Agent foaf:mbox ?email . }
+  OPTIONAL { ?Agent foaf:workplaceHomepage ?workplaceHomepage . }
+  OPTIONAL { ?Agent foaf:phone ?phone . }
+}
+```

--- a/src/docs/case-study/case-study-fresh.md
+++ b/src/docs/case-study/case-study-fresh.md
@@ -10,8 +10,6 @@ mapping_type: "Schema Mapping"
 status: "Draft"
 ---
 
-### The title of your use case
-
 FReSH catalog case study.
 
 ### Domain


### PR DESCRIPTION
@StroemPhi can you review please? I made some small edits to your original submission; the most significant edit is that I do not believe your (very great) case studies are cases of "entity" but "schema mappings". For example, the dcat-ap -> schema.org mapping maps data structures described with DCAT-AT metadata to schema.org - not just the underlying entity mappings.