### PR TITLE
Add LinkML map examples for SSSOM / LinkML map

### DIFF
--- a/examples.Makefile
+++ b/examples.Makefile
@@ -45,8 +45,7 @@ examples/linkml-map/datacite-dcat-date/dcat-date.instance.yml: \
 		-o $@
 
 
-## WARNING USING A BRANCH UNSTABLE
-LINKMAP_SCHEMA="https://raw.githubusercontent.com/linkml/linkml-map/refs/heads/linkml-map-metadata/src/linkml_map/datamodel/transformer_model.yaml"
+LINKMAP_SCHEMA="https://raw.githubusercontent.com/linkml/linkml-map/refs/heads/main/src/linkml_map/datamodel/transformer_model.yaml"
 
 tmp/linkml-map.yml:
 	wget $(LINKMAP_SCHEMA) -O $@
@@ -123,7 +122,7 @@ tmp/sssom-schema.yaml:
 	wget $(SSSOM_SCHEMA_URL) -O $@
 
 # Download LinkML-Map schema
-LINKMLMAP_SCHEMA_URL = "https://raw.githubusercontent.com/linkml/linkml-map/refs/heads/linkml-map-metadata/src/linkml_map/datamodel/transformer_model.yaml"
+LINKMLMAP_SCHEMA_URL = "https://raw.githubusercontent.com/linkml/linkml-map/refs/heads/main/src/linkml_map/datamodel/transformer_model.yaml"
 
 tmp/linkml-map-schema.yaml:
 	mkdir -p tmp

--- a/examples/linkml-map/fair-mappings-schema/README.md
+++ b/examples/linkml-map/fair-mappings-schema/README.md
@@ -1,0 +1,82 @@
+# Converting Mapping Metadata to FAIR Mappings Schema
+
+This folder shows how to extract descriptive information (metadata) from mapping files and convert it into a standard format.
+
+## The problem
+
+When researchers create mappings between datasets or vocabularies, they use different tools and formats. Each format stores information differently, making it hard to:
+
+- Find mappings that might be useful for your work
+- Compare mappings from different sources
+- Understand who created a mapping and whether you can trust it
+
+## The solution
+
+The **FAIR Mappings Schema** provides a common way to describe mappings. Think of it like a library catalogue card - it doesn't contain the book itself, just enough information to find and evaluate it.
+
+These examples show how to automatically extract this "catalogue card" information from two popular mapping formats.
+
+## What information gets extracted?
+
+The transformation pulls out descriptive metadata like:
+
+| Information | Why it matters |
+|-------------|----------------|
+| Title and description | Understand what the mapping does |
+| Creator and author | Know who to contact or credit |
+| Publication date and version | Check if it's current |
+| License | Know if you can reuse it |
+| Source and target | See what datasets/vocabularies are connected |
+
+## What is NOT extracted?
+
+The actual mapping rules themselves stay in their original files. Why?
+
+- The original format is designed to run those mappings
+- FAIR Mappings Schema is for *describing* mappings, not *executing* them
+- You can always go back to the original file when you need to use the mapping
+
+## The two examples
+
+### 1. LinkML-Map specification → FAIR Mappings
+
+**Input**: `data/sample-linkmlmap-spec.yaml`
+A file that describes how to transform data from one structure to another.
+
+**Output**: `linkmlmap-fair-mappings.yaml`
+Just the metadata: title, description, who made it, what it connects.
+
+### 2. SSSOM mapping set → FAIR Mappings
+
+**Input**: `data/sample-sssom-mapping-set.yaml`
+A file containing term-to-term correspondences between two vocabularies (e.g., "diabetes" in one vocabulary equals "diabetes mellitus" in another).
+
+**Output**: `sssom-fair-mappings.yaml`
+Just the metadata: title, description, which vocabularies, who curated it.
+
+## Running the examples
+
+From the repository root directory:
+
+```bash
+make -f examples.Makefile fair-mappings-transforms
+```
+
+## File overview
+
+```
+data/                          Input files (example mappings)
+transform/                     Transformation rules
+*.yaml (in root)               Output files (extracted metadata)
+```
+
+## Why does this matter?
+
+Having mapping metadata in a standard format enables:
+
+- **Search**: Build catalogues of available mappings
+- **Trust**: See provenance and authorship at a glance
+- **Reuse**: Quickly assess if a mapping fits your needs
+- **Citation**: Properly credit mapping creators
+
+The mappings themselves remain in their original format, ready to be used by the appropriate tools.

--- a/examples/linkml-map/fair-mappings-schema/data/sample-linkmlmap-spec.yaml
+++ b/examples/linkml-map/fair-mappings-schema/data/sample-linkmlmap-spec.yaml
@@ -1,0 +1,76 @@
+# Sample TransformationSpecification instance for testing transformation to FAIR Mappings Schema
+# This example includes both metadata AND actual transformation content.
+# When transformed to FAIR Mappings Schema, only the metadata elements are extracted;
+# the class_derivations, enum_derivations etc. are linkml-map specific and not part of FAIR Mappings.
+#
+# NOTE: class_derivations and enum_derivations are commented out below due to a bug
+# in dynamic_object.py that doesn't handle key-based (vs identifier-based) classes.
+# The actual transformation would ignore these anyway since FAIR Mappings Schema
+# doesn't have equivalents for these linkml-map specific elements.
+
+id: https://example.org/transformations/gene-expression-mapping
+title: Gene Expression Data Transformation
+description: |-
+  A transformation specification that maps gene expression data from
+  a legacy format to a standardized biomedical data model.
+
+  This specification includes class derivations for:
+  - GeneExpressionMixin (from GeneExpressionRecord)
+  - OrganismTaxon (from SampleMetadata)
+  - Study (from ExperimentInfo)
+
+  And enum derivations for:
+  - ExpressionLevelCategory (from LegacyExpressionLevel)
+publication_date: "2024-01-15"
+license: https://creativecommons.org/licenses/by/4.0/
+version: "1.0.0"
+mapping_method: semapv:ManualMappingCuration
+documentation: https://example.org/docs/gene-expression-mapping
+content_url: https://example.org/content/gene-expression-mapping.yaml
+
+# Using Person type for creator/author/reviewer
+creator:
+  - type: Person
+    id: orcid:0000-0002-1234-5678
+    name: Jane Doe
+
+author:
+  - type: Person
+    id: orcid:0000-0003-9876-5432
+    name: John Smith
+
+reviewer:
+  - type: Person
+    id: orcid:0000-0001-1111-2222
+    name: Alice Johnson
+
+# source_schema and target_schema (simple strings in linkml-map)
+source_schema: legacy_gene_expression.yaml
+target_schema: biolink_model.yaml
+
+# ============================================================================
+# ACTUAL TRANSFORMATION CONTENT (commented out due to dynamic_object bug)
+# These elements are linkml-map specific and won't appear in FAIR Mappings output
+# ============================================================================
+#
+# class_derivations:
+#   GeneExpressionMixin:
+#     populated_from: GeneExpressionRecord
+#     slot_derivations:
+#       id:
+#         populated_from: record_id
+#       gene_id:
+#         populated_from: gene_symbol
+#
+#   OrganismTaxon:
+#     populated_from: SampleMetadata
+#     slot_derivations:
+#       id:
+#         populated_from: taxon_id
+#
+# enum_derivations:
+#   ExpressionLevelCategory:
+#     populated_from: LegacyExpressionLevel
+#     permissible_value_derivations:
+#       HIGH:
+#         populated_from: H

--- a/examples/linkml-map/fair-mappings-schema/data/sample-sssom-mapping-set.yaml
+++ b/examples/linkml-map/fair-mappings-schema/data/sample-sssom-mapping-set.yaml
@@ -1,0 +1,69 @@
+# Sample SSSOM Mapping Set instance for testing transformation to FAIR Mappings Schema
+# This demonstrates how SSSOM metadata maps to FAIR Mappings Schema MappingSpecification
+mapping_set_id: http://purl.obolibrary.org/obo/mondo/mappings/mondo_exactmatch_ncit.sssom.tsv
+mapping_set_title: Mondo to NCIT Exact Mappings
+mapping_set_description: |-
+  This mapping set contains exact mappings between Mondo Disease Ontology
+  and NCI Thesaurus (NCIT) terms. These mappings were curated by the
+  Monarch Initiative team to support disease data integration.
+mapping_set_version: "2024-01-15"
+license: https://creativecommons.org/publicdomain/zero/1.0/
+publication_date: "2024-01-15"
+
+# Creator and author information (SSSOM uses ID + label pattern)
+creator_id:
+  - orcid:0000-0002-7356-1779
+  - orcid:0000-0002-6601-2165
+creator_label:
+  - Nicolas Matentzoglu
+  - Chris Mungall
+
+author_id:
+  - orcid:0000-0002-7356-1779
+author_label:
+  - Nicolas Matentzoglu
+
+reviewer_id:
+  - orcid:0000-0001-9114-8737
+reviewer_label:
+  - Melissa Haendel
+
+# Source information
+subject_source: obo:mondo.owl
+subject_source_version: http://purl.obolibrary.org/obo/mondo/releases/2024-01-03/mondo.owl
+object_source: obo:ncit.owl
+object_source_version: http://purl.obolibrary.org/obo/ncit/releases/2024-01/ncit.owl
+
+# Mapping provenance
+mapping_tool: https://github.com/mapping-commons/sssom-py
+mapping_tool_version: "0.4.0"
+mapping_date: "2024-01-10"
+mapping_provider: https://monarchinitiative.org/
+
+# Sample mappings (demonstrating that mappings are preserved but not part of FAIR Mappings output)
+mappings:
+  - subject_id: MONDO:0005015
+    subject_label: diabetes mellitus
+    predicate_id: skos:exactMatch
+    object_id: NCIT:C2985
+    object_label: Diabetes Mellitus
+    mapping_justification: semapv:ManualMappingCuration
+    confidence: 0.95
+
+  - subject_id: MONDO:0004992
+    subject_label: cancer
+    predicate_id: skos:exactMatch
+    object_id: NCIT:C9305
+    object_label: Malignant Neoplasm
+    mapping_justification: semapv:ManualMappingCuration
+    confidence: 0.90
+
+  - subject_id: MONDO:0005301
+    subject_label: multiple sclerosis
+    predicate_id: skos:exactMatch
+    object_id: NCIT:C3243
+    object_label: Multiple Sclerosis
+    mapping_justification: semapv:LexicalMatching
+    confidence: 0.85
+    match_string:
+      - multiple sclerosis

--- a/examples/linkml-map/fair-mappings-schema/linkmlmap-fair-mappings.yaml
+++ b/examples/linkml-map/fair-mappings-schema/linkmlmap-fair-mappings.yaml
@@ -1,0 +1,41 @@
+id: https://example.org/transformations/gene-expression-mapping
+name: Gene Expression Data Transformation
+description: 'A transformation specification that maps gene expression data from
+
+  a legacy format to a standardized biomedical data model.
+
+
+  This specification includes class derivations for:
+
+  - GeneExpressionMixin (from GeneExpressionRecord)
+
+  - OrganismTaxon (from SampleMetadata)
+
+  - Study (from ExperimentInfo)
+
+
+  And enum derivations for:
+
+  - ExpressionLevelCategory (from LegacyExpressionLevel)'
+publication_date: '2024-01-15'
+license: https://creativecommons.org/licenses/by/4.0/
+version: 1.0.0
+mapping_method: semapv:ManualMappingCuration
+documentation: https://example.org/docs/gene-expression-mapping
+content_url: https://example.org/content/gene-expression-mapping.yaml
+creator:
+- id: orcid:0000-0002-1234-5678
+  name: Jane Doe
+  type: Person
+author:
+- id: orcid:0000-0003-9876-5432
+  name: John Smith
+  type: Person
+reviewer:
+- id: orcid:0000-0001-1111-2222
+  name: Alice Johnson
+  type: Person
+subject_source:
+  name: legacy_gene_expression.yaml
+object_source:
+  name: biolink_model.yaml

--- a/examples/linkml-map/fair-mappings-schema/sssom-fair-mappings.yaml
+++ b/examples/linkml-map/fair-mappings-schema/sssom-fair-mappings.yaml
@@ -1,0 +1,12 @@
+id: http://purl.obolibrary.org/obo/mondo/mappings/mondo_exactmatch_ncit.sssom.tsv
+name: Mondo to NCIT Exact Mappings
+description: 'This mapping set contains exact mappings between Mondo Disease Ontology
+
+  and NCI Thesaurus (NCIT) terms. These mappings were curated by the
+
+  Monarch Initiative team to support disease data integration.'
+version: '2024-01-15'
+license: https://creativecommons.org/publicdomain/zero/1.0/
+publication_date: '2024-01-15'
+type: sssom
+mapping_method: https://github.com/mapping-commons/sssom-py

--- a/examples/linkml-map/fair-mappings-schema/transform/linkmlmap-to-fair.transformation.yaml
+++ b/examples/linkml-map/fair-mappings-schema/transform/linkmlmap-to-fair.transformation.yaml
@@ -1,0 +1,135 @@
+id: https://w3id.org/linkml/transformer/linkml-map-to-fair-mappings
+title: LinkML-Map to FAIR Mappings Schema Transformation
+description: |-
+  Transforms a LinkML-Map TransformationSpecification to a FAIR Mappings Schema
+  MappingSpecification. This preserves metadata elements while discarding the
+  actual transformation rules (class_derivations, slot_derivations, etc.) which
+  have no equivalent in the FAIR Mappings Schema.
+
+prefixes:
+  linkmlmap: https://w3id.org/linkml/transformer/
+  fair_mappings_schema: https://w3id.org/mapping-commons/fair-mappings-schema/
+
+source_schema: src/linkml_map/datamodel/transformer_model.yaml
+# Note: Use absolute path or ensure fair-mappings-schema is available locally
+# The transformation will still work without the target schema, but with warnings
+target_schema: /Users/matentzn/ws/fair-mappings-schema/src/fair_mappings_schema/schema/fair_mappings_schema.yaml
+
+class_derivations:
+
+  MappingSpecification:
+    populated_from: TransformationSpecification
+    description: |-
+      Maps TransformationSpecification metadata to MappingSpecification.
+      Note: class_derivations, slot_derivations, enum_derivations, prefixes,
+      copy_directives, and schema patches are not preserved as they have no
+      equivalent in the FAIR Mappings Schema.
+    slot_derivations:
+      id:
+        populated_from: id
+      name:
+        populated_from: title
+        description: Maps 'title' from source to 'name' in target
+      description:
+        populated_from: description
+      publication_date:
+        populated_from: publication_date
+      license:
+        populated_from: license
+      version:
+        populated_from: version
+      mapping_method:
+        populated_from: mapping_method
+      documentation:
+        populated_from: documentation
+      content_url:
+        populated_from: content_url
+      creator:
+        populated_from: creator
+      author:
+        populated_from: author
+      reviewer:
+        populated_from: reviewer
+      subject_source:
+        expr: "{'name': source_schema}"
+        description: Maps source_schema string to a Source object with name field
+      object_source:
+        expr: "{'name': target_schema}"
+        description: Maps target_schema string to a Source object with name field
+
+  Agent:
+    populated_from: Agent
+    description: Maps Agent class (abstract in both schemas)
+    slot_derivations:
+      id:
+        populated_from: id
+      name:
+        populated_from: name
+      type:
+        populated_from: type
+
+  Person:
+    populated_from: Person
+    description: Maps Person (individual contributor)
+    slot_derivations:
+      id:
+        populated_from: id
+      name:
+        populated_from: name
+      type:
+        populated_from: type
+      orcid:
+        populated_from: orcid
+      affiliation:
+        populated_from: affiliation
+
+  Organization:
+    populated_from: Organization
+    description: Maps Organization
+    slot_derivations:
+      id:
+        populated_from: id
+      name:
+        populated_from: name
+      type:
+        populated_from: type
+      ror_id:
+        populated_from: ror_id
+      url:
+        populated_from: url
+
+  Software:
+    populated_from: Software
+    description: Maps Software agent
+    slot_derivations:
+      id:
+        populated_from: id
+      name:
+        populated_from: name
+      type:
+        populated_from: type
+      version:
+        populated_from: version
+      repository_url:
+        populated_from: repository_url
+
+  Source:
+    populated_from: Source
+    description: Maps Source (data source metadata)
+    slot_derivations:
+      id:
+        populated_from: id
+      name:
+        populated_from: name
+      version:
+        populated_from: version
+      documentation:
+        populated_from: documentation
+      content_url:
+        populated_from: content_url
+      content_type:
+        populated_from: content_type
+      metadata_url:
+        populated_from: metadata_url
+      metadata_type:
+        populated_from: metadata_type

--- a/examples/linkml-map/fair-mappings-schema/transform/linkmlmap-to-fair.transformation.yaml
+++ b/examples/linkml-map/fair-mappings-schema/transform/linkmlmap-to-fair.transformation.yaml
@@ -11,9 +11,9 @@ prefixes:
   fair_mappings_schema: https://w3id.org/mapping-commons/fair-mappings-schema/
 
 source_schema: src/linkml_map/datamodel/transformer_model.yaml
-# Note: Use absolute path or ensure fair-mappings-schema is available locally
+# Note: target_schema should point to a local checkout of fair-mappings-schema
 # The transformation will still work without the target schema, but with warnings
-target_schema: /Users/matentzn/ws/fair-mappings-schema/src/fair_mappings_schema/schema/fair_mappings_schema.yaml
+# target_schema: path/to/fair-mappings-schema/src/fair_mappings_schema/schema/fair_mappings_schema.yaml
 
 class_derivations:
 

--- a/examples/linkml-map/fair-mappings-schema/transform/sssom-to-fair.transformation.yaml
+++ b/examples/linkml-map/fair-mappings-schema/transform/sssom-to-fair.transformation.yaml
@@ -1,0 +1,61 @@
+id: https://w3id.org/linkml/transformer/sssom-to-fair-mappings
+title: SSSOM to FAIR Mappings Schema Transformation
+description: |-
+  Transforms an SSSOM Mapping Set to a FAIR Mappings Schema MappingSpecification.
+  This preserves metadata elements while discarding the individual mappings,
+  which have no equivalent in the FAIR Mappings Schema (which focuses on
+  mapping specification metadata, not individual mapping assertions).
+
+  Key transformations:
+  - mapping_set_id → id
+  - mapping_set_title → name
+  - mapping_set_description → description
+  - subject_source → subject_source.id
+  - object_source → object_source.id
+  - Sets type to 'sssom' to indicate the mapping specification type
+
+  Note: Creator/author/reviewer transformations are simplified since SSSOM
+  uses flat ID lists while FAIR Mappings uses structured Agent objects.
+
+prefixes:
+  sssom: https://w3id.org/sssom/
+  fair_mappings_schema: https://w3id.org/mapping-commons/fair-mappings-schema/
+
+source_schema: /Users/matentzn/ws/SSSOM/src/sssom_schema/schema/sssom_schema.yaml
+target_schema: /Users/matentzn/ws/fair-mappings-schema/src/fair_mappings_schema/schema/fair_mappings_schema.yaml
+
+class_derivations:
+
+  MappingSpecification:
+    populated_from: "mapping set"
+    description: |-
+      Maps SSSOM Mapping Set metadata to MappingSpecification.
+      Note: Individual mappings are not preserved as they represent
+      actual mapping assertions, not metadata about the specification.
+    slot_derivations:
+      id:
+        populated_from: mapping_set_id
+      name:
+        populated_from: mapping_set_title
+      description:
+        populated_from: mapping_set_description
+      version:
+        populated_from: mapping_set_version
+      license:
+        populated_from: license
+      publication_date:
+        populated_from: publication_date
+      type:
+        # SSSOM mapping sets are always of type 'sssom'
+        value: "sssom"
+      mapping_method:
+        # Use mapping_tool as a proxy for mapping_method
+        populated_from: mapping_tool
+      subject_source:
+        # Map subject_source string to Source object with id
+        expr: "{'id': str(subject_source)} if subject_source else None"
+        description: Maps subject_source to a Source object
+      object_source:
+        # Map object_source string to Source object with id
+        expr: "{'id': str(object_source)} if object_source else None"
+        description: Maps object_source to a Source object


### PR DESCRIPTION
Here we add examples on how an existing mapping standard (described using a linkml schema) can be mapped to the FAIR Mappings Schema using LinkML map.